### PR TITLE
GOK-172 | Refactor. Get provider UUID from mapping

### DIFF
--- a/bahmni/src/main/java/org/avni_integration_service/bahmni/BahmniMappingGroup.java
+++ b/bahmni/src/main/java/org/avni_integration_service/bahmni/BahmniMappingGroup.java
@@ -15,6 +15,7 @@ public class BahmniMappingGroup {
     public final MappingGroup programEncounter;
     public final MappingGroup observation;
     public final MappingGroup common;
+    public final MappingGroup user;
 
     @Autowired
     public BahmniMappingGroup(MappingGroupRepository mappingGroupRepository) {
@@ -24,5 +25,6 @@ public class BahmniMappingGroup {
         this.programEncounter = mappingGroupRepository.findByName("ProgramEncounter");
         this.observation = mappingGroupRepository.findByName("Observation");
         this.common = mappingGroupRepository.findByName("Common");
+        this.user = mappingGroupRepository.findByName("User");
     }
 }

--- a/bahmni/src/main/java/org/avni_integration_service/bahmni/BahmniMappingType.java
+++ b/bahmni/src/main/java/org/avni_integration_service/bahmni/BahmniMappingType.java
@@ -35,6 +35,7 @@ public class BahmniMappingType {
     public final MappingType avniEventDateVisitAttributeType;
     public final MappingType avniUUIDVisitAttributeType;
     public final MappingType concept;
+    public final MappingType providerUUID;
 
     @Autowired
     public BahmniMappingType(MappingTypeRepository mappingTypeRepository) {
@@ -63,5 +64,6 @@ public class BahmniMappingType {
         this.avniEventDateVisitAttributeType = mappingTypeRepository.findByName("AvniEventDate_VisitAttributeType");
         this.avniUUIDVisitAttributeType = mappingTypeRepository.findByName("AvniUUID_VisitAttributeType");
         this.concept = mappingTypeRepository.findByName("Concept");
+        this.providerUUID = mappingTypeRepository.findByName("ProviderUUID");
     }
 }

--- a/bahmni/src/main/java/org/avni_integration_service/bahmni/mapper/avni/EncounterMapper.java
+++ b/bahmni/src/main/java/org/avni_integration_service/bahmni/mapper/avni/EncounterMapper.java
@@ -54,7 +54,7 @@ public class EncounterMapper {
         openMRSEncounter.setEncounterType(encounterTypeUuid);
         openMRSEncounter.setEncounterDatetime(MapperUtils.getEventDateTime(baseEncounter.getEncounterDateTime(), visit));
         openMRSEncounter.setLocation(constants.getValue(ConstantKey.IntegrationBahmniLocation.name()));
-        openMRSEncounter.addEncounterProvider(new OpenMRSEncounterProvider(constants.getValue(ConstantKey.IntegrationBahmniProvider.name()),
+        openMRSEncounter.addEncounterProvider(new OpenMRSEncounterProvider(mappingService.getProviderUUIDForAvniUser(baseEncounter.getLastModifiedBy(), constants),
                 constants.getValue(ConstantKey.IntegrationBahmniEncounterRole.name())));
 
         List<OpenMRSSaveObservation> observations = observationMapper.mapObservations(baseEncounter.getObservations());
@@ -106,7 +106,7 @@ public class EncounterMapper {
         openMRSEncounter.setPatient(existingEncounter.getPatient().getUuid());
         openMRSEncounter.setEncounterType(encounterTypeUuid);
         openMRSEncounter.setLocation(constants.getValue(ConstantKey.IntegrationBahmniLocation.name()));
-        openMRSEncounter.addEncounterProvider(new OpenMRSEncounterProvider(constants.getValue(ConstantKey.IntegrationBahmniProvider.name()), constants.getValue(ConstantKey.IntegrationBahmniEncounterRole.name())));
+        openMRSEncounter.addEncounterProvider(new OpenMRSEncounterProvider(mappingService.getProviderUUIDForAvniUser(avniBaseEncounter.getLastModifiedBy(),constants), constants.getValue(ConstantKey.IntegrationBahmniEncounterRole.name())));
 
         String avniUuidConcept = mappingService.getBahmniValueForAvniIdConcept();
         String eventDateConcept = mappingService.getBahmniValue(bahmniMappingGroup.common, bahmniMappingType.avniEventDateConcept);

--- a/bahmni/src/main/java/org/avni_integration_service/bahmni/mapper/avni/SubjectMapper.java
+++ b/bahmni/src/main/java/org/avni_integration_service/bahmni/mapper/avni/SubjectMapper.java
@@ -35,7 +35,7 @@ public class SubjectMapper {
         openMRSEncounter.setEncounterType(encounterTypeUuid);
         openMRSEncounter.setLocation(constants.getValue(ConstantKey.IntegrationBahmniLocation.name()));
 
-        var encounterProvider = new OpenMRSEncounterProvider(constants.getValue(ConstantKey.IntegrationBahmniProvider.name()),
+        var encounterProvider = new OpenMRSEncounterProvider(mappingService.getProviderUUIDForAvniUser(subject.getLastModifiedBy(),constants),
                 constants.getValue(ConstantKey.IntegrationBahmniEncounterRole.name()));
         openMRSEncounter.addEncounterProvider(encounterProvider);
 
@@ -57,7 +57,7 @@ public class SubjectMapper {
         openMRSEncounter.setPatient(existingEncounter.getPatient().getUuid());
         openMRSEncounter.setEncounterType(encounterTypeUuid);
         openMRSEncounter.setLocation(constants.getValue(ConstantKey.IntegrationBahmniLocation.name()));
-        openMRSEncounter.addEncounterProvider(new OpenMRSEncounterProvider(constants.getValue(ConstantKey.IntegrationBahmniProvider.name()), constants.getValue(ConstantKey.IntegrationBahmniEncounterRole.name())));
+        openMRSEncounter.addEncounterProvider(new OpenMRSEncounterProvider(mappingService.getProviderUUIDForAvniUser(subject.getLastModifiedBy(),constants), constants.getValue(ConstantKey.IntegrationBahmniEncounterRole.name())));
 
         var observations = observationMapper.updateOpenMRSObservationsFromAvniObservations(
                 existingEncounter.getLeafObservations(),

--- a/bahmni/src/main/java/org/avni_integration_service/bahmni/repository/intmapping/MappingService.java
+++ b/bahmni/src/main/java/org/avni_integration_service/bahmni/repository/intmapping/MappingService.java
@@ -2,7 +2,9 @@ package org.avni_integration_service.bahmni.repository.intmapping;
 
 import org.avni_integration_service.bahmni.BahmniMappingGroup;
 import org.avni_integration_service.bahmni.BahmniMappingType;
+import org.avni_integration_service.bahmni.ConstantKey;
 import org.avni_integration_service.bahmni.MappingMetaDataCollection;
+import org.avni_integration_service.integration_data.domain.Constants;
 import org.avni_integration_service.integration_data.domain.MappingGroup;
 import org.avni_integration_service.integration_data.domain.MappingMetaData;
 import org.avni_integration_service.integration_data.domain.MappingType;
@@ -94,5 +96,15 @@ public class MappingService {
 
     public MappingMetaData findByMappingGroupAndMappingType(MappingGroup patientSubject, MappingType mappingType) {
         return mappingMetaDataRepository.findByMappingGroupAndMappingType(patientSubject, mappingType);
+    }
+
+    public String getProviderUUIDForAvniUser(String avniUser, Constants constants) {
+        if (avniUser == null) {
+            return constants.getValue(ConstantKey.IntegrationBahmniProvider.name());
+        }
+        String providerUuid = getBahmniValue(bahmniMappingGroup.user, bahmniMappingType.providerUUID, avniUser);
+        if (providerUuid == null)
+            providerUuid = constants.getValue(ConstantKey.IntegrationBahmniProvider.name());
+        return providerUuid;
     }
 }

--- a/bahmni/src/main/resources/db/migration/V2_2_2__Bahmni_Provider_Mapping.sql
+++ b/bahmni/src/main/resources/db/migration/V2_2_2__Bahmni_Provider_Mapping.sql
@@ -1,0 +1,2 @@
+insert into mapping_group (name, integration_system_id) values ('User', (select id from integration_system where name = 'bahmni'));
+insert into mapping_type (name, integration_system_id) values ('ProviderUUID', (select id from integration_system where name = 'bahmni'));


### PR DESCRIPTION
This PR adds changes for defining Avni User to OpenMRS Provider UUID mapping.
- Added new mapping group `User`
- Added new mapping type `ProviderUUID`
- Refactor mapping service to not pass constant UUID

Now for every user created in Avni, a corresponding provider needs to be created in Bahmni and the UUID needs to be mapped. 
Example:
<img width="1470" alt="Screenshot 2023-06-21 at 7 15 24 PM" src="https://github.com/Bahmni-HWC/integration-service/assets/31698165/612c7ba0-9f5e-46d5-a4f0-da24ef730f31">

Once a proper mapping is set this is how the Bahmni UI will look like
<img width="1356" alt="Screenshot 2023-06-21 at 7 16 43 PM" src="https://github.com/Bahmni-HWC/integration-service/assets/31698165/ee539542-ed56-43b9-8fd4-4ed985b682f7">

Note: If in case a proper mapping is not set the integration-service will sync data with the name of `Offline Sync`